### PR TITLE
UI-2639: px-slider cannot render min/max labels.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v2.2.3
+==================
+* Fix min/max labels cannot render/visible.
+
 v2.2.2
 ==================
 * Added workaround for a Firefox bug where getScreenCTM doesnt work right when the svg is in a transformed HTML element

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-slider",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": [
     "px-slider.html"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-slider",
   "author": "General Electric",
   "description": "Predix UI slider component",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-slider.html
+++ b/px-slider.html
@@ -196,8 +196,8 @@ Custom property | Description
             return {
               left: 15,
               right: 15,
-              top: 15,
-              bottom: 10
+              top: 30,
+              bottom: 25
             };
           }
         },


### PR DESCRIPTION
- If 'isRange' set to true, min/max labels needs to sit below/or above those draggable triangle handles(based on maxLabelPosition), hence it require bit more margin, otherwise those labels are in the dom but hidden.
- Please note that the overall slider grow taller by another 30px(considering you might use triangle handles, if it's just circular handles then we can bring it down by another 10px)
- In-addition to above changes, component needs to pass-in showLabels={true} since it's default is false.

<img width="598" alt="screen shot 2018-12-14 at 12 15 16 am" src="https://user-images.githubusercontent.com/34659014/49991890-52121100-ff37-11e8-9656-09408accca8f.png">
<img width="541" alt="screen shot 2018-12-14 at 12 15 30 am" src="https://user-images.githubusercontent.com/34659014/49991899-5807f200-ff37-11e8-865e-1636ef4f1862.png">
