### PR TITLE
UI-3121: Fix min/max labels overlapping on Edge.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v2.2.4
+==================
+* Fix min/max labels overlapping on Edge.
+
 v2.2.3
 ==================
 * Fix min/max labels cannot render/visible.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-slider",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": [
     "px-slider.html"
   ],

--- a/demo/px-slider-demo.html
+++ b/demo/px-slider-demo.html
@@ -194,7 +194,7 @@ limitations under the License.
 
       showLabels: {
         type: Boolean,
-        defaultValue: false,
+        defaultValue: true,
         inputType: 'toggle'
       },
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-slider",
   "author": "General Electric",
   "description": "Predix UI slider component",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-slider.html
+++ b/px-slider.html
@@ -197,7 +197,7 @@ Custom property | Description
               left: 15,
               right: 15,
               top: 30,
-              bottom: 25
+              bottom: 30
             };
           }
         },
@@ -1249,10 +1249,10 @@ Custom property | Description
 
       _returnLabelPosition(labelPosition, isRange) {
         if(isRange) {
-          return labelPosition === 'top' ? -20 : 24;
+          return labelPosition === 'top' ? -20 : 29;
         }
         else {
-          return labelPosition === 'top' ? -15 : 19;
+          return labelPosition === 'top' ? -15 : 24;
         }
       },
 


### PR DESCRIPTION
- Fix min/max labels overlapping on Edge.